### PR TITLE
Fix AdminLoggingSettingService db usage

### DIFF
--- a/services/admin_logging_setting_service.py
+++ b/services/admin_logging_setting_service.py
@@ -5,7 +5,8 @@ from repositories.admin_logging_setting_repository import AdminLoggingSettingRep
 from models.admin_logging_setting import AdminLoggingSetting # For type hinting if needed
 
 class AdminLoggingSettingService:
-    def __init__(self, db: Session): # Changed to accept Session directly
+    def __init__(self, db: Session):  # Changed to accept Session directly
+        self.db = db
         self.repository = AdminLoggingSettingRepository(db)
 
     def get_all_settings(self) -> Dict[str, bool]:


### PR DESCRIPTION
## Summary
- store the database session in AdminLoggingSettingService

## Testing
- `pytest tests/unit/services/test_admin_logging_setting_service.py -q` *(fails: The asyncio extension requires an async driver to be used)*

------
https://chatgpt.com/codex/tasks/task_e_684973d0cbd883338b71013b6850b1b3